### PR TITLE
[personal, wip] fix integer overflow

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -933,7 +933,7 @@ func configureAssumeRole(obj cty.Value) *awsbase.AssumeRole {
 	assumeRole := awsbase.AssumeRole{}
 
 	assumeRole.RoleARN = stringAttr(obj, "role_arn")
-	assumeRole.Duration = time.Duration(intAttr(obj, "assume_role_duration_seconds") * int(time.Second))
+	assumeRole.Duration = time.Duration(int64(intAttr(obj, "assume_role_duration_seconds")) * int64(time.Second))
 	assumeRole.ExternalID = stringAttr(obj, "external_id")
 	assumeRole.Policy = stringAttr(obj, "assume_role_policy")
 	assumeRole.SessionName = stringAttr(obj, "session_name")


### PR DESCRIPTION
Fixed one small case of integer overflows, and the remaining all seem to be in that same category.

The usage of cty seems to be pretty tied to `int` vs `int64`, i.e. it's looking like it would be a large lift to convert to int64. While it would likely be a large but safe change, I'm not sure if it would be worth the churn given the likely low priority of support 386 architectures.